### PR TITLE
Use an ip range instead of looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,18 +282,16 @@ and you will also see 'puppet' in the service list when you issue ```firewall-cm
      port => [{'port' => '4321', 'protocol' => 'udp'}, {'protocol' => 'rdp'}],
   ```
 
-The `port` parameter can also take a range of ports separated by a colon, for example:
+The `port` parameter can also take a range of ports separated by a colon or a dash (colons are replaced by dashes), for example:
 
 ```puppet
    port => [ {'port' => '8000:8002', 'protocol' => 'tcp']} ]
 ```
 
-will produce;
+will produce:
 
 ```xml
-    <port protocol="tcp" port="8000" />
-    <port protocol="tcp" port="8001" />
-    <port protocol="tcp" port="8002" />
+    <port protocol="tcp" port="8000-8002" />
 ```
 
 * `module`: (Optional) An array of strings specifying netfilter kernel helper modules associated with this service

--- a/spec/fixtures/services/custom_service_port_range.xml
+++ b/spec/fixtures/services/custom_service_port_range.xml
@@ -3,12 +3,8 @@
     <short>myservice</short>
     <description>My multi port service</description>
 
-    <port protocol="tcp" port="8000" />
-    <port protocol="tcp" port="8001" />
-    <port protocol="tcp" port="8002" />
-    <port protocol="udp" port="8000" />
-    <port protocol="udp" port="8001" />
-    <port protocol="udp" port="8002" />
+    <port protocol="tcp" port="8000-8002" />
+    <port protocol="udp" port="8000-8002" />
 
     <module name="nf_conntrack_netbios_ns" />
 

--- a/templates/service.xml.erb
+++ b/templates/service.xml.erb
@@ -8,10 +8,8 @@
     <%- if @port -%>
     <%- @port.each do |i| -%>
       <%- if i['port'] and i['port'] != '' -%>
-        <%- range = sprintf('%s',i['port']).split(/:/).map { |p| p.to_i } -%>
-        <%- (range[0]..range[1] || range[0]).each do |p| -%>
+        <%- p = sprintf('%s',i['port']).sub(/:/, '-') -%>
     <port<% if i['protocol'] -%> protocol="<%= i['protocol'] %>"<% end -%> port="<%= p %>" />
-        <%- end -%>
       <%- else -%>
     <port protocol="<%= i['protocol'] %>" port="" />
       <%- end -%>


### PR DESCRIPTION
I'm unsure why this was not yet implemented this way - I'm ready to be educated today :-)

I tested it on our servers (centos/rhel 7), this worked before I used the `puppet-firewalld` module, and I was very surprised to find the xml file to be expanded :-)