### PR TITLE
Bugfix/setting service ensure to stopped causes failure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,9 +89,12 @@ class firewalld (
       enable => $service_enable,
     }
 
-    exec { 'firewalld::reload':
-      command     => 'firewall-cmd --reload',
-      refreshonly => true,
+    # The following command won't work if the service is stopped
+    if $service_ensure != 'stopped' {
+      exec { 'firewalld::reload':
+        command     => 'firewall-cmd --reload',
+        refreshonly => true,
+      }
     }
 
     exec { 'firewalld::complete-reload':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,12 +89,11 @@ class firewalld (
       enable => $service_enable,
     }
 
-    # The following command won't work if the service is stopped
-    if $service_ensure != 'stopped' {
-      exec { 'firewalld::reload':
-        command     => 'firewall-cmd --reload',
-        refreshonly => true,
-      }
+    # firewall-cmd commands won't work if the service is stopped
+    exec { 'firewalld::reload':
+      command     => 'firewall-cmd --reload',
+      refreshonly => true,
+      onlyif      => 'firewall-cmd --state',
     }
 
     exec { 'firewalld::complete-reload':


### PR DESCRIPTION
This is a fix for issue 164. If the firewalld service is running and this module is called with service_ensure => 'stopped' then the puppet run fails because firewall-cmd commands need the firewalld service to be running in order to work.

https://github.com/crayfishx/puppet-firewalld/issues/164