### PR TITLE
Rubocop fix: Style/PredicateName

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:firewalld_zone) do
       end
     end
 
-    def is_to_s(value = [])
+    def is_to_s(value = []) # rubocop:disable Style/PredicateName
       '[' + value.join(', ') + ']'
     end
 


### PR DESCRIPTION
`is_to_s` is part of the Puppet API.

This is not a 'boolean method' as described here.
https://github.com/rubocop-hq/ruby-style-guide#bool-methods-prefix

`is` and `should` values are a puppet resource property concept.