### PR TITLE
Rubocop fix Lint/UselessAssignment

### DIFF
--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -29,9 +29,9 @@ class Puppet::Provider::Firewalld < Puppet::Provider
 
   def self.check_running_state
     debug("Executing --state command - current value #{@state}")
-    ret = execute_firewall_cmd(['--state'], nil, false, false, check_online = false)
+    ret = execute_firewall_cmd(['--state'], nil, false, false, false)
     Puppet::Provider::Firewalld.runstate = ret.exitstatus.zero?
-  rescue Puppet::MissingCommand => e
+  rescue Puppet::MissingCommand
     # This exception is caught in case the module is being run before
     # the package provider has installed the firewalld package, if we
     # cannot find the firewalld-cmd command then we silently continue

--- a/lib/puppet/type/firewalld_direct_purge.rb
+++ b/lib/puppet/type/firewalld_direct_purge.rb
@@ -56,7 +56,6 @@ Puppet::Type.newtype(:firewalld_direct_purge) do
   end
 
   def purge_resources
-    resources = []
     resource_type = self[:name].to_sym
     klass = nil
 
@@ -69,7 +68,6 @@ Puppet::Type.newtype(:firewalld_direct_purge) do
       klass = Puppet::Type::Firewalld_direct_rule
     end
 
-    purge_rules = []
     puppet_rules = []
 
     catalog.resources.select { |r| r.is_a?(klass) }.each do |res|

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -162,7 +162,6 @@ Puppet::Type.newtype(:firewalld_zone) do
 
   def purge_rich_rules
     return [] unless provider.exists?
-    purge_rules = []
     puppet_rules = []
     catalog.resources.select { |r| r.is_a?(Puppet::Type::Firewalld_rich_rule) }.each do |fwr|
       debug("not purging puppet controlled rich rule #{fwr[:name]}")
@@ -191,7 +190,6 @@ Puppet::Type.newtype(:firewalld_zone) do
 
   def purge_services
     return [] unless provider.exists?
-    purge_services = []
     puppet_services = []
     catalog.resources.select { |r| r.is_a?(Puppet::Type::Firewalld_service) }.each do |fws|
       if fws[:zone] == self[:name]
@@ -215,7 +213,6 @@ Puppet::Type.newtype(:firewalld_zone) do
 
   def purge_ports
     return [] unless provider.exists?
-    purge_ports = []
     puppet_ports = []
     catalog.resources.select { |r| r.is_a?(Puppet::Type::Firewalld_port) }.each do |fwp|
       if fwp[:zone] == self[:name]


### PR DESCRIPTION
I think some of these unused variables were left over from a previous
version.

Perhaps they should have been removed as part of
https://github.com/voxpupuli/puppet-firewalld/pull/74 ??