### PR TITLE
Rubocop fix/disable Style/AccessorMethodName

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -149,6 +149,7 @@ Puppet::Type.type(:firewalld_zone).provide(
     end
   end
 
+  # rubocop:disable Style/AccessorMethodName
   def get_rules
     perm = execute_firewall_cmd(['--list-rich-rules']).split(%r{\n})
     curr = execute_firewall_cmd(['--list-rich-rules'], @resource[:name], false).split(%r{\n})
@@ -179,6 +180,7 @@ Puppet::Type.type(:firewalld_zone).provide(
   def get_icmp_types
     execute_firewall_cmd(['--get-icmptypes'], nil).split(' ')
   end
+  # rubocop:enable Style/AccessorMethodName
 
   def description
     execute_firewall_cmd(['--get-description'], @resource[:name], true, false)


### PR DESCRIPTION
I think these are ok named as is, as we're specifically 'getting' the data
from the system by calling an external command. In the case of eg
`get_icmp_types`, there is already an attribute accessor `icmp_types`.
The `get_` method is its helper.

See https://github.com/rubocop-hq/ruby-style-guide#accessor_mutator_method_names