### PR TITLE
Fix rubocop Lint/EmptyWhen

### DIFF
--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -59,7 +59,8 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
       args << quote_keyval('protocol', @resource[:port]['protocol'])
     when :icmp_block
       args << quote_keyval('name', @resource[:icmp_block])
-    when :masquerade
+    # when :masquerade
+    #   `masquerade` doesn't accept any arguments.
     when :forward_port
       args << quote_keyval('port',     @resource[:forward_port]['port'])
       args << quote_keyval('protocol', @resource[:forward_port]['protocol'])


### PR DESCRIPTION
There has been some discussion about whether an empty block with a comment should raise a warning or not [here](https://github.com/rubocop-hq/rubocop/issues/3696).