### PR TITLE
Fix firewall commands being run on compiler

### DIFF
--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -10,17 +10,13 @@ class Puppet::Provider::Firewalld < Puppet::Provider
     attr_accessor :runstate
   end
 
-  def initialize(*args)
-    check_running_state if state.nil?
-    super
-  end
-
   def state
     self.class.state
   end
 
   def self.state
     Puppet::Provider::Firewalld.runstate
+    check_running_state
   end
 
   def check_running_state


### PR DESCRIPTION
This ensures that the firewall status commands are only run on clients
instead of being run on the compiler as well.

This was tested via Beaker testing in simp/iptables 6.4.0.

Closes #225