### PR TITLE
Update README ipset ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ firewalld::ipsets:
 
 * `entries`: An array of entries for the IPset
 * `type`: Type of ipset (default: `hash:ip`)
-* `options`: A hash of options for the IPset (eg: `{ "family" => "ipv6"}`)
+* `options`: A hash of options for the IPset (eg: `{ "family" => "inet6"}`)
 
 Note that `type` and `options` are parameters used when creating the IPset and are not managed after creation - to change the type or options of an ipset you must delete the existing ipset first.
 


### PR DESCRIPTION
When making an IPset, in the readme file it says to use "ipv6" for IPv6 addresses

{ "family" => "ipv6" } when it should be
{ "family" => "inet6" } unless this module should be changing ipv6 to inet6 in the background

firewall-cmd won't accept ipv6

firewall-cmd --version
0.6.3

CentOS Linux release 8.0.1905