### PR TITLE
Native type autorequires for the firewalld service

### DIFF
--- a/lib/puppet/type/firewalld_direct_chain.rb
+++ b/lib/puppet/type/firewalld_direct_chain.rb
@@ -45,4 +45,8 @@ Puppet::Type.newtype(:firewalld_direct_chain) do
     desc 'Name of the table type to add (e.g: filter, nat, mangle, raw)'
     isnamevar
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_direct_passthrough.rb
+++ b/lib/puppet/type/firewalld_direct_passthrough.rb
@@ -32,4 +32,8 @@ Puppet::Type.newtype(:firewalld_direct_passthrough) do
     isnamevar
     desc 'Name of the passthroughhrough to add (e.g: -A OUTPUT -j OUTPUT_filter)'
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_direct_purge.rb
+++ b/lib/puppet/type/firewalld_direct_purge.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:firewalld_direct_purge) do
     newvalues('chain', 'passthrough', 'rule')
   end
 
+  autorequire(:service) do
+    ['firewalld']
+  end
+
   def purge?
     !@purge_resources.empty?
   end

--- a/lib/puppet/type/firewalld_direct_rule.rb
+++ b/lib/puppet/type/firewalld_direct_rule.rb
@@ -44,4 +44,8 @@ Puppet::Type.newtype(:firewalld_direct_rule) do
   newparam(:args) do
     desc '<args> can be all iptables, ip6tables and ebtables command line arguments'
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -93,4 +93,8 @@ Puppet::Type.newtype(:firewalld_ipset) do
       raise(Puppet::Error, "Ipset should not declare entries if it doesn't manage entries")
     end
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_port.rb
+++ b/lib/puppet/type/firewalld_port.rb
@@ -47,4 +47,8 @@ Puppet::Type.newtype(:firewalld_port) do
   autorequire(:firewalld_zone) do
     self[:zone]
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -127,4 +127,8 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
   autorequire(:ipset) do
     self[:source]['ipset'] if self[:source].is_a?(Hash)
   end
+
+  autorequire(:service) do
+    ['firewalld']
+  end
 end

--- a/lib/puppet/type/firewalld_service.rb
+++ b/lib/puppet/type/firewalld_service.rb
@@ -45,8 +45,9 @@ Puppet::Type.newtype(:firewalld_service) do
   end
 
   autorequire(:service) do
-    catalog.resources.select do |res|
-      res.title == "Firewalld::Custom_service[#{self[:service]}]"
-    end
+    ['firewalld'] +
+      catalog.resources.select do |res|
+        res.title == "Firewalld::Custom_service[#{self[:service]}]"
+      end
   end
 end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -52,6 +52,14 @@ Puppet::Type.newtype(:firewalld_zone) do
     desc 'Name of the zone'
   end
 
+  newparam(:description) do
+    desc 'Description of the zone to add'
+  end
+
+  newparam(:short) do
+    desc 'Short description of the zone to add'
+  end
+
   newproperty(:target) do
     desc 'Specify the target for the zone'
   end
@@ -151,6 +159,10 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
   end
 
+  autorequire(:service) do
+    ['firewalld']
+  end
+
   def purge_resource(res_type)
     if Puppet.settings[:noop] || self[:noop]
       Puppet.debug "Would have purged #{res_type.ref}, (noop)"
@@ -232,13 +244,5 @@ Puppet::Type.newtype(:firewalld_zone) do
       purge_resource(res_type)
       @ports_purgable = true
     end
-  end
-
-  newparam(:description) do
-    desc 'Description of the zone to add'
-  end
-
-  newparam(:short) do
-    desc 'Short description of the zone to add'
   end
 end

--- a/spec/unit/puppet/type/firewalld_direct_chain_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_chain_spec.rb
@@ -50,17 +50,19 @@ describe Puppet::Type.type(:firewalld_direct_chain) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => 'ipv4:filter:LOG_DROPS')
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: 'ipv4:filter:LOG_DROPS')
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_direct_chain_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_chain_spec.rb
@@ -48,4 +48,19 @@ describe Puppet::Type.type(:firewalld_direct_chain) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => 'ipv4:filter:LOG_DROPS')
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_direct_passthrough_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_passthrough_spec.rb
@@ -53,17 +53,19 @@ describe Puppet::Type.type(:firewalld_direct_passthrough) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => '-A OUTPUT -j OUTPUT_filter')
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: '-A OUTPUT -j OUTPUT_filter')
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_direct_passthrough_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_passthrough_spec.rb
@@ -51,4 +51,19 @@ describe Puppet::Type.type(:firewalld_direct_passthrough) do
       provider.destroy
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => '-A OUTPUT -j OUTPUT_filter')
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
@@ -80,8 +80,9 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
@@ -97,11 +98,12 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
       }
     end
 
-    it 'should autorequire the firewalld service' do
+    it 'autorequires the firewalld service' do
       @resource = described_class.new(attrs)
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
@@ -78,4 +78,30 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    let(:attrs) do
+      {
+        title: 'Allow SSH',
+        ensure: 'present',
+        table: 'filter',
+        chain: 'OUTPUT',
+        priority: 1,
+        args: '-p tcp ---dport=22 -j ACCEPT'
+      }
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(attrs)
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -157,17 +157,19 @@ describe Puppet::Type.type(:firewalld_ipset) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => 'test', hashsize: 128)
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: 'test', hashsize: 128)
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -155,4 +155,19 @@ describe Puppet::Type.type(:firewalld_ipset) do
       end.to raise_error(%r{Ipset should not declare entries if it doesn't manage entries})
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => 'test', hashsize: 128)
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_port_spec.rb
+++ b/spec/unit/puppet/type/firewalld_port_spec.rb
@@ -20,4 +20,19 @@ describe Puppet::Type.type(:firewalld_port) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => 'test', :port => 1234)
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_port_spec.rb
+++ b/spec/unit/puppet/type/firewalld_port_spec.rb
@@ -22,17 +22,19 @@ describe Puppet::Type.type(:firewalld_port) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => 'test', :port => 1234)
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: 'test', port: 1234)
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -204,4 +204,31 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    let(:attrs) do
+      {
+        title: 'SSH from barny',
+        ensure: 'present',
+        zone: 'restricted',
+        source: '192.168.1.2/32',
+        dest: '192.168.99.2/32',
+        service: 'ssh',
+        action: 'accept'
+      }
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(attrs)
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -206,8 +206,9 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
@@ -224,11 +225,12 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
       }
     end
 
-    it 'should autorequire the firewalld service' do
+    it 'autorequires the firewalld service' do
       @resource = described_class.new(attrs)
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_service_spec.rb
+++ b/spec/unit/puppet/type/firewalld_service_spec.rb
@@ -22,17 +22,19 @@ describe Puppet::Type.type(:firewalld_service) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => 'test', :service => 'test')
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: 'test', service: 'test')
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_service_spec.rb
+++ b/spec/unit/puppet/type/firewalld_service_spec.rb
@@ -20,4 +20,19 @@ describe Puppet::Type.type(:firewalld_service) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => 'test', :service => 'test')
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -163,17 +163,19 @@ describe Puppet::Type.type(:firewalld_zone) do
   end
 
   context 'autorequires' do
-    before :each do
-      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+    # rubocop:disable RSpec/InstanceVariable
+    before do
+      @firewalld_service = Puppet::Type.type(:service).new(name: 'firewalld')
       @catalog = Puppet::Resource::Catalog.new
       @catalog.add_resource(@firewalld_service)
     end
 
-    it 'should autorequire the firewalld service' do
-      @resource = described_class.new(:name => 'test')
+    it 'autorequires the firewalld service' do
+      @resource = described_class.new(name: 'test')
       @catalog.add_resource(@resource)
 
-      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+      expect(@resource.autorequire.map { |rp| rp.source.to_s }).to include('Service[firewalld]')
     end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -161,4 +161,19 @@ describe Puppet::Type.type(:firewalld_zone) do
       end
     end
   end
+
+  context 'autorequires' do
+    before :each do
+      @firewalld_service = Puppet::Type.type(:service).new(:name => 'firewalld')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource(@firewalld_service)
+    end
+
+    it 'should autorequire the firewalld service' do
+      @resource = described_class.new(:name => 'test')
+      @catalog.add_resource(@resource)
+
+      expect(@resource.autorequire.map{|rp| rp.source.to_s}).to include('Service[firewalld]')
+    end
+  end
 end


### PR DESCRIPTION
* Added an autorequire for each native type that uses firewall-cmd. This
  is due to what appears to be the requirement that any firewall-cmd
  activities occur after the service has been started the first time.
  Running commands prior to the service start can result in malformed
  configurations being applied to the system which silently break the
  firewalld service.
* Tested against simp/iptables 6.4.0
      
Closes #224