### PR TITLE
memoize self.state

### DIFF
--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -102,6 +102,10 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   end
 
   def self.online?
+    # always re-check state unless we are already online:
+    # see #117 / 813141cbfebf98c4348b64189cb472b6f3238c99
+    # That means, `self.state` will be re-run, even if it has a valid value, such as `false`
+    Puppet::Provider::Firewalld.runstate = check_running_state unless state == true
     state == true
   end
 

--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -15,8 +15,10 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   end
 
   def self.state
+    if Puppet::Provider::Firewalld.runstate.nil?
+      Puppet::Provider::Firewalld.runstate = check_running_state
+    end
     Puppet::Provider::Firewalld.runstate
-    check_running_state
   end
 
   def check_running_state
@@ -26,7 +28,7 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   def self.check_running_state
     debug("Executing --state command - current value #{@state}")
     ret = execute_firewall_cmd(['--state'], nil, false, false, false)
-    Puppet::Provider::Firewalld.runstate = ret.exitstatus.zero?
+    ret.exitstatus.zero?
   rescue Puppet::MissingCommand
     # This exception is caught in case the module is being run before
     # the package provider has installed the firewalld package, if we

--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -94,7 +94,6 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   end
 
   def offline?
-    check_running_state if state.nil?
     state == false || state.nil?
   end
 
@@ -103,7 +102,6 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   end
 
   def self.online?
-    check_running_state unless state == true
     state == true
   end
 
@@ -116,7 +114,6 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   end
 
   def self.available?
-    check_running_state if state.nil?
     !state.nil?
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

we memoize the output of check_running_state.

this also helps clarify the name of the function
`self.check_running_state`, which now no longer modifies a class-global
variable, and instead just returns the state


This pull Request is a Regression and is caused by #232 / #225 (which the author naïvely approved)

#### This Pull Request (PR) fixes the following issues

Fixes #240 