### PR TITLE
(#250) Replace newer ruby %i syntax with older supported syntax

### DIFF
--- a/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
@@ -61,7 +61,7 @@ Puppet::Type.type(:firewalld_ipset).provide(
     @resource[:entries].each { |e| add_entry(e) } if @resource[:manage_entries]
   end
 
-  %i[type maxelem family hashsize timeout].each do |method|
+  [:type, :maxelem, :family, :hashsize, :timeout].each do |method|
     define_method("#{method}=") do |should|
       info("Destroying and creating ipset #{@resource[:name]}")
       destroy

--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
   end
 
   def elements
-    %i[service port protocol icmp_block masquerade forward_port]
+    [:service, :port, :protocol, :icmp_block, :masquerade, :forward_port]
   end
 
   def eval_element

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
     end
     validate do |value|
       if value.is_a?(Hash)
-        if value.keys.sort != %i[action type]
+        if value.keys.sort != [ :action, :type ]
           raise Puppet::Error, "Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got #{value}"
         end
         _validate_action(value[:action])
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
   end
 
   def elements
-    %i[service port protocol icmp_block masquerade forward_port]
+    [:service, :port, :protocol, :icmp_block, :masquerade, :forward_port]
   end
 
   validate do


### PR DESCRIPTION
Ruby <2.0 and jruby <9k don't support %i syntax.
This commit changes the %i syntax to the older equivalent.

#### Pull Request (PR) description
Fix for issue #250 to support older ruby versions.

#### This Pull Request (PR) fixes the following issues
Fixes #250
