### PR TITLE
check for running firewalld in custom_service::reload

### DIFF
--- a/manifests/custom_service.pp
+++ b/manifests/custom_service.pp
@@ -55,6 +55,7 @@ define firewalld::custom_service (
   exec{ "firewalld::custom_service::reload-${name}":
     path        =>'/usr/bin:/bin',
     command     => 'firewall-cmd --reload',
+    onlyif      => 'firewall-cmd --state',
     refreshonly => true,
   }
 


### PR DESCRIPTION
firewall-cmd --reload won't work if the service is stopped. The exec-resource firewalld::reload has an "onlyif" statement, in firewalld::custom_service::reload-${name} it is missing, so I added it.

#### Pull Request (PR) description
Added an onlyif condition to firewalld::custom_service::reload to trigger only if firewalld is running. This check is already added in firewalld::reload. 

#### This Pull Request (PR) fixes the following issues
n/a.
