### PR TITLE
Add firewalld_version fact

### DIFF
--- a/lib/facter/firewalld_version.rb
+++ b/lib/facter/firewalld_version.rb
@@ -1,0 +1,11 @@
+# Return the version of firewalld that is installed
+Facter.add(:firewalld_version) do
+  confine { Process.uid.zero? }
+
+  @firewall_cmd = Facter::Util::Resolution.which('firewall-cmd')
+  confine { @firewall_cmd }
+
+  setcode do
+    Facter::Core::Execution.execute(%(#{@firewall_cmd} --version), on_fail: :failed).strip
+  end
+end

--- a/spec/unit/facter/firewalld_version_spec.rb
+++ b/spec/unit/facter/firewalld_version_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'firewalld_version' do
+  before do
+    Facter.clear
+
+    Process.stubs(:uid).returns(0)
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    Facter::Util::Resolution.stubs(:which).with('firewall-cmd').returns('/usr/bin/firewall-cmd')
+    Facter::Core::Execution.stubs(:execute).with('/usr/bin/firewall-cmd --version', on_fail: :failed).returns(firewalld_version)
+  end
+
+  context 'as a regular user' do
+    let(:firewalld_version) { "0.7.0\n" }
+
+    it 'does not return a fact' do
+      Process.stubs(:uid).returns(1)
+
+      expect(Facter.fact('firewalld_version').value).to be_nil
+    end
+  end
+
+  context 'firewall-cmd succeeds' do
+    let(:firewalld_version) { "0.7.0\n" }
+
+    it 'returns a valid version' do
+      expect(Facter.fact('firewalld_version').value).to eq(firewalld_version.strip)
+    end
+  end
+
+  context 'firewall-cmd fails' do
+    let(:firewalld_version) { :failed }
+
+    it 'does not return a fact' do
+      expect(Facter.fact('firewalld_version').value).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Added a firewalld_version fact to support features that are dependent on
the version of firewalld that is installed.

Fixes #254

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
