### PR TITLE
Fix the firewalld_version fact

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -24,7 +24,7 @@ Gemfile:
       - gem: 'mocha'
         version: '~> 1.10.0'
     ':system_tests':
-      - gem: 'beaker-vagrant'
+      - gem: 'simp-beaker-helpers'
 
 .rubocop.yml:
   default_configs:

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :system_tests do
   gem 'rbnacl-libsodium',                   :require => false
   gem 'bcrypt_pbkdf',                       :require => false
   gem 'ed25519',                            :require => false
-  gem 'beaker-vagrant',                     :require => false
+  gem 'simp-beaker-helpers',                :require => false
 end
 
 group :release do

--- a/lib/facter/firewalld_version.rb
+++ b/lib/facter/firewalld_version.rb
@@ -2,10 +2,36 @@
 Facter.add(:firewalld_version) do
   confine { Process.uid.zero? }
 
-  @firewall_cmd = Facter::Util::Resolution.which('firewall-cmd')
+  @firewall_cmd = Facter::Util::Resolution.which('firewall-offline-cmd')
   confine { @firewall_cmd }
 
   setcode do
-    Facter::Core::Execution.execute(%(#{@firewall_cmd} --version), on_fail: :failed).strip
+    def failed_value?(value)
+      !value || (value == :failed) || value.empty?
+    end
+
+    value = Facter::Core::Execution.execute(%(#{@firewall_cmd} --version), on_fail: :failed)
+
+    if failed_value?(value)
+      # Python gets stuck in some weird places
+      python = Facter::Util::Resolution.which('python')
+      python ||= Facter::Util::Resolution.which('platform-python')
+
+      python_path = '/usr/libexec/platform-python'
+      python ||= python_path if File.exist?(python_path)
+
+      # Because firewall-cmd fails if firewalld is not running
+      workaround_command = %{#{python} -c 'import firewall.config; print(firewall.config.__dict__["VERSION"])'}
+
+      value = Facter::Core::Execution.execute(workaround_command, on_fail: :failed)
+    end
+
+    if failed_value?(value)
+      value = nil
+    else
+      value.strip!
+    end
+
+    value
   end
 end

--- a/rakelib/simp.rake
+++ b/rakelib/simp.rake
@@ -1,0 +1,7 @@
+begin
+  require 'simp/rake/beaker'
+
+  Simp::Rake::Beaker.new(File.join(File.dirname(__FILE__), '..'))
+rescue LoadError
+  $stderr.puts('simp-beaker-helpers not loaded, some acceptance test functionality may be missing')
+end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -59,6 +59,11 @@ describe 'firewalld', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) d
         test_services = on(host, 'firewall-cmd --list-services --zone=test').output.strip.split(%r{\s+})
         expect(test_services).to include('test_sshd')
       end
+
+      it 'returns a fact when firewalld is not running' do
+        on(host, 'puppet resource service firewalld ensure=stopped')
+        expect(pfact_on(host, 'firewalld_version')).to match(%r{^\d})
+      end
     end
   end
 end

--- a/spec/unit/facter/firewalld_version_spec.rb
+++ b/spec/unit/facter/firewalld_version_spec.rb
@@ -6,8 +6,12 @@ describe 'firewalld_version' do
 
     Process.stubs(:uid).returns(0)
     Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-    Facter::Util::Resolution.stubs(:which).with('firewall-cmd').returns('/usr/bin/firewall-cmd')
-    Facter::Core::Execution.stubs(:execute).with('/usr/bin/firewall-cmd --version', on_fail: :failed).returns(firewalld_version)
+    Facter::Util::Resolution.stubs(:which).with('firewall-offline-cmd').returns('/usr/bin/firewall-offline-cmd')
+    Facter::Core::Execution.stubs(:execute).with('/usr/bin/firewall-offline-cmd --version', on_fail: :failed).returns(firewalld_version)
+  end
+
+  let(:python_args) do
+    %{-c 'import firewall.config; print(firewall.config.__dict__["VERSION"])'}
   end
 
   context 'as a regular user' do
@@ -32,6 +36,9 @@ describe 'firewalld_version' do
     let(:firewalld_version) { :failed }
 
     it 'does not return a fact' do
+      Facter::Util::Resolution.stubs(:which).with('python').returns('/usr/bin/python')
+      Facter::Core::Execution.stubs(:execute).with("/usr/bin/python #{python_args}", on_fail: :failed).returns(:failed)
+
       expect(Facter.fact('firewalld_version').value).to be_nil
     end
   end


### PR DESCRIPTION
* Work around a bug in firewall-cmd and use raw python to get the
  firewalld version if firewalld-cmd does not return anything
* Incorporated the simp-beaker-helpers gem to get access to the helper
  methods

Fixes #263

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
