### PR TITLE
Parse arguments to passthrough provider with spaces correctly

### DIFF
--- a/lib/puppet/provider/firewalld_direct_passthrough/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_passthrough/firewall_cmd.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:firewalld_direct_passthrough).provide(
     passt = []
     passt << [
       @resource[:inet_protocol],
-      @resource[:args].split(' ')
+      parse_args(@resource[:args])
     ]
     passt.flatten
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Right now if you use a rule which has spaces in their arguments, it just
ignores them and creates an invalid rule (e.g. --comment 'foo bar'). As
there is already a method for that in firewalld_direct_rule, just use it
like there.