### PR TITLE
Quick fix for inert newvalues statements

### DIFF
--- a/lib/puppet/type/firewalld_custom_service.rb
+++ b/lib/puppet/type/firewalld_custom_service.rb
@@ -153,8 +153,6 @@ Puppet::Type.newtype(:firewalld_custom_service) do
   newproperty(:ipv4_destination) do
     desc 'The IPv4 destination network of the service'
 
-    newvalues(%r{^[^/]+(/\d+)?$})
-
     defaultto(:unset)
 
     validate do |value|
@@ -179,8 +177,6 @@ Puppet::Type.newtype(:firewalld_custom_service) do
 
   newproperty(:ipv6_destination) do
     desc 'The IPv6 destination network of the service'
-
-    newvalues(%r{^[^/]+(/\d+)?$})
 
     defaultto(:unset)
 

--- a/spec/unit/puppet/type/firewalld_custom_service_spec.rb
+++ b/spec/unit/puppet/type/firewalld_custom_service_spec.rb
@@ -258,7 +258,7 @@ describe Puppet::Type.type(:firewalld_custom_service) do
               name: 'test',
               ipv4_destination: destination
             )
-          end. to raise_error(%r{(Valid values match|invalid address|not an IPv4)})
+          end. to raise_error(%r{(invalid address|not an IPv4)})
         end
       end
     end
@@ -300,7 +300,7 @@ describe Puppet::Type.type(:firewalld_custom_service) do
               name: 'test',
               ipv6_destination: destination
             )
-          end. to raise_error(%r{(Valid values match|invalid address|not an IPv6)})
+          end. to raise_error(%r{(invalid address|not an IPv6)})
         end
       end
     end


### PR DESCRIPTION
The `newvalues` statements should have been removed when the `validate` methods were added.
