### PR TITLE
Allow the use of dots in the name of an ipset

### DIFF
--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:firewalld_ipset) do
   newparam(:name, namevar: true) do
     desc 'Name of the IPset'
     validate do |val|
-      raise Puppet::Error, 'IPset name must be a word with no spaces' unless val =~ %r{^[\w-]+$}
+      raise Puppet::Error, 'IPset name must be a word with no spaces' unless val =~ %r{^[\w\.-]+$}
     end
   end
 

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -83,6 +83,14 @@ describe Puppet::Type.type(:firewalld_ipset) do
         )
       end.not_to raise_error
     end
+    it 'accept . in name' do
+      expect do
+        described_class.new(
+          name: 'white.blue',
+          type: 'hash:net'
+        )
+      end.not_to raise_error
+    end
   end
 
   ## Provider tests for the firewalld_zone type


### PR DESCRIPTION
### Pull Request (PR) description
I have a usecase where i want to be able to use dots in the name of an ipset, this changes makes that possible. Firewalld doesn't mind and it has been running for a while now in production.
