### PR TITLE
fixed puppet-lint warning regarding missing namespace

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,8 +227,8 @@ class firewalld (
     }
   }
 
-  if $facts['firewalld_version'] and
-    (versioncmp($facts['firewalld_version'], '0.6.0') >= 0) and
+  if $::facts['firewalld_version'] and
+    (versioncmp($::facts['firewalld_version'], '0.6.0') >= 0) and
     $firewall_backend
   {
     augeas {


### PR DESCRIPTION
#### Pull Request (PR) description
Added Top-Scope namespace to $facts[] usage.
#### This Pull Request (PR) fixes the following issues
puppet-lint shows warnings "top-scope variable being used without an explicit namespace".  This PR adds the top-scope namespace like so "$::facts[]" as mentioned in http://puppet-lint.com/checks/variable_scope/
