### PR TITLE
Update firewalld custom service to translate port ranges with a colon…

### DIFF
--- a/lib/puppet/type/firewalld_custom_service.rb
+++ b/lib/puppet/type/firewalld_custom_service.rb
@@ -51,7 +51,8 @@ Puppet::Type.newtype(:firewalld_custom_service) do
       return value if value == :unset
 
       if value.is_a?(Hash)
-        value = Hash[value.map { |k, v| [k, v.to_s] }]
+        # Handle the legacy format from the module translate : to -
+        value = Hash[value.map { |k, v| [k, v.to_s.tr(':', '-')] }]
       else
         port, protocol = value.split('/')
 

--- a/spec/unit/puppet/type/firewalld_custom_service_spec.rb
+++ b/spec/unit/puppet/type/firewalld_custom_service_spec.rb
@@ -80,6 +80,7 @@ describe Puppet::Type.type(:firewalld_custom_service) do
       '65535/tcp',
       'tcp',
       { 'protocol' => 'tcp' },
+      { 'port' => '1234:4567', 'protocol' => 'tcp' },
       { 'port' => 1234, 'protocol' => 'tcp' },
       { 'port' => 1234, 'protocol' => 'udp' },
       { 'port' => 1234, 'protocol' => 'sctp' },


### PR DESCRIPTION
… in hashes

#### Pull Request (PR) description
Make sure colon is replaced with a dash with firewalld_custom_service when using a port range in a hash

#### This Pull Request (PR) fixes the following issues
Fixes #292