### PR TITLE
Support specifying priority on rich rules

### DIFF
--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -23,6 +23,11 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
     quote_keyval(opt, @resource[resource_param.to_s])
   end
 
+  def eval_priority
+    return [] unless (priority = @resource[:priority])
+    quote_keyval('priority', priority)
+  end
+
   def eval_source
     args = []
     return [] unless (addr = @resource[:source])
@@ -112,6 +117,7 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
     rule = ['rule']
     rule << [
       key_val_opt('family'),
+      eval_priority,
       eval_source,
       eval_dest,
       eval_element,

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -36,6 +36,15 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
     munge(&:to_s)
   end
 
+  newparam(:priority) do
+    desc 'Rule priority, it can be in the range of -32768 to 32767'
+    munge(&:to_s)
+
+    validate do |value|
+      raise Puppet::Error, 'Priority must be between -32768 and 32767' unless value.to_i.to_s == value.to_s && (-32768..32767).include?(value.to_i)
+    end
+  end
+
   newparam(:source) do
     desc 'Specify source address, this can be a string of the IP address or a hash containing other options'
     munge do |value|

--- a/spec/unit/puppet/provider/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_rich_rule_spec.rb
@@ -26,6 +26,7 @@ describe provider_class do
   describe 'when creating' do
     context 'with basic parameters' do
       it 'builds the rich rule' do
+        resource.expects(:[]).with(:priority).returns(nil)
         resource.expects(:[]).with(:source).returns('192.168.1.2/32').at_least_once
         resource.expects(:[]).with(:service).returns('ssh').at_least_once
         resource.expects(:[]).with('family').returns('ipv4').at_least_once
@@ -45,6 +46,7 @@ describe provider_class do
     end
     context 'with reject type' do
       it 'builds the rich rule' do
+        resource.expects(:[]).with(:priority).returns(nil)
         resource.expects(:[]).with(:source).returns(nil).at_least_once
         resource.expects(:[]).with(:service).returns('ssh').at_least_once
         resource.expects(:[]).with('family').returns('ipv4').at_least_once
@@ -60,6 +62,26 @@ describe provider_class do
         resource.expects(:[]).with(:raw_rule).returns(nil)
         resource.expects(:[]).with(:action).returns(action: 'reject', type: 'icmp-admin-prohibited')
         expect(provider.build_rich_rule).to eq('rule family="ipv4" destination address="192.168.0.1/32" service name="ssh" reject type="icmp-admin-prohibited"')
+      end
+    end
+    context 'with priority' do
+      it 'builds the rich rule' do
+        resource.expects(:[]).with(:priority).returns(1200)
+        resource.expects(:[]).with(:source).returns(nil).at_least_once
+        resource.expects(:[]).with(:service).returns('ssh').at_least_once
+        resource.expects(:[]).with('family').returns('ipv4').at_least_once
+        resource.expects(:[]).with(:dest).returns('address' => '192.168.0.1/32')
+        resource.expects(:[]).with(:port).returns(nil)
+        resource.expects(:[]).with(:protocol).returns(nil)
+        resource.expects(:[]).with(:icmp_block).returns(nil)
+        resource.expects(:[]).with(:icmp_type).returns(nil)
+        resource.expects(:[]).with(:masquerade).returns(nil)
+        resource.expects(:[]).with(:forward_port).returns(nil)
+        resource.expects(:[]).with(:log).returns(nil)
+        resource.expects(:[]).with(:audit).returns(nil)
+        resource.expects(:[]).with(:raw_rule).returns(nil)
+        resource.expects(:[]).with(:action).returns(action: 'reject', type: 'icmp-admin-prohibited')
+        expect(provider.build_rich_rule).to eq('rule family="ipv4" priority="1200" destination address="192.168.0.1/32" service name="ssh" reject type="icmp-admin-prohibited"')
       end
     end
   end

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -91,6 +91,41 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
     end
   end
 
+  describe 'priority validation' do
+    it 'raises an error if invalid priority' do
+      expect do
+        described_class.new(
+          title: 'SSH from barny',
+          priority: 'none'
+        )
+      end.to raise_error(%r{Priority must be between -32768 and 32767})
+    end
+    it 'raises an error if too low priority' do
+      expect do
+        described_class.new(
+          title: 'SSH from barny',
+          priority: -32769
+        )
+      end.to raise_error(%r{Priority must be between -32768 and 32767})
+    end
+    it 'raises an error if too high priority' do
+      expect do
+        described_class.new(
+          title: 'SSH from barny',
+          priority: 32768
+        )
+      end.to raise_error(%r{Priority must be between -32768 and 32767})
+    end
+    it 'does not raises an error if priority is valid' do
+      expect do
+        described_class.new(
+          title: 'SSH from barny',
+          priority: 10
+        )
+      end.not_to raise_error()
+    end
+  end
+
   ## Many more scenarios needed!
   #
   describe 'provider' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Adds support for the `priority` option on rich rules, to allow ordering them outside of the normally implicit - and not guaranteed to be deterministic - ordering imposed by when they're added.