### PR TITLE
enable eb-family for all relevant firewalld-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ firewalld::direct_chains:
 #### Parameters (Firewalld Direct Chains)
 
 * `name`: name of the chain, eg `LOG_DROPS`  (namevar)
-* `inet_protocol`: ipv4 or ipv6, defaults to ipv4 (namevar)
+* `inet_protocol`: ipv4, ipv6 or eb, defaults to ipv4 (namevar)
 * `table`: The table (eg: filter) to apply the chain (namevar)
 
 ### Firewalld Direct Rules
@@ -674,7 +674,7 @@ firewalld::direct_rules:
 
 * `name`: Resource name in Puppet
 * `ensure`: present or absent
-* `inet_protocol`: ipv4 or ipv6, defaults to ipv4
+* `inet_protocol`: ipv4, ipv6 or eb, defaults to ipv4
 * `table`: Table (eg: filter) which to apply the rule
 * `chain`: Chain (eg: OUTPUT) which to apply the rule
 * `priority`: The priority number of the rule (e.g: 0, 1, 2, ... 99)
@@ -709,7 +709,7 @@ firewalld::direct_passthroughs:
 
 * `name`: Resource name in Puppet
 * `ensure`: present or absent
-* `inet_protocol`: ipv4 or ipv6, defaults to ipv4
+* `inet_protocol`: ipv4, ipv6 or eb, defaults to ipv4
 * `args`: Name of the passthroughhrough to add (e.g:
   -A OUTPUT -j OUTPUT_filter)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -490,11 +490,11 @@ The following parameters are available in the `firewalld_direct_chain` type.
 
 ##### <a name="-firewalld_direct_chain--inet_protocol"></a>`inet_protocol`
 
-Valid values: `ipv4`, `ipv6`
+Valid values: `ipv4`, `ipv6`, `eb`
 
 namevar
 
-Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)
+Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)
 
 Default value: `ipv4`
 
@@ -559,9 +559,9 @@ Name of the passthroughhrough to add (e.g: -A OUTPUT -j OUTPUT_filter)
 
 ##### <a name="-firewalld_direct_passthrough--inet_protocol"></a>`inet_protocol`
 
-Valid values: `ipv4`, `ipv6`
+Valid values: `ipv4`, `ipv6`, `eb`
 
-Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)
+Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)
 
 Default value: `ipv4`
 
@@ -669,9 +669,9 @@ Name of the chain type to add (e.g: INPUT, OUTPUT, FORWARD)
 
 ##### <a name="-firewalld_direct_rule--inet_protocol"></a>`inet_protocol`
 
-Valid values: `ipv4`, `ipv6`
+Valid values: `ipv4`, `ipv6`, `eb`
 
-Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)
+Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)
 
 Default value: `ipv4`
 
@@ -1043,9 +1043,9 @@ Specify destination address, this can be a string of the IP address or a hash co
 
 ##### <a name="-firewalld_rich_rule--family"></a>`family`
 
-Valid values: `ipv4`, `ipv6`
+Valid values: `ipv4`, `ipv6`, `eb`
 
-IP family, one of ipv4 or ipv6, defauts to ipv4
+IP family, one of ipv4, ipv6 or eb, defauts to ipv4
 
 Default value: `ipv4`
 

--- a/lib/puppet/type/firewalld_direct_chain.rb
+++ b/lib/puppet/type/firewalld_direct_chain.rb
@@ -39,8 +39,8 @@ Puppet::Type.newtype(:firewalld_direct_chain) do
   end
 
   newparam(:inet_protocol) do
-    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)'
-    newvalues('ipv4', 'ipv6')
+    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)'
+    newvalues('ipv4', 'ipv6', 'eb')
     defaultto('ipv4')
     munge(&:to_s)
     isnamevar

--- a/lib/puppet/type/firewalld_direct_passthrough.rb
+++ b/lib/puppet/type/firewalld_direct_passthrough.rb
@@ -27,8 +27,8 @@ Puppet::Type.newtype(:firewalld_direct_passthrough) do
   end
 
   newparam(:inet_protocol) do
-    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)'
-    newvalues('ipv4', 'ipv6')
+    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)'
+    newvalues('ipv4', 'ipv6', 'eb')
     defaultto('ipv4')
     munge(&:to_s)
   end

--- a/lib/puppet/type/firewalld_direct_rule.rb
+++ b/lib/puppet/type/firewalld_direct_rule.rb
@@ -28,8 +28,8 @@ Puppet::Type.newtype(:firewalld_direct_rule) do
   end
 
   newparam(:inet_protocol) do
-    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6)'
-    newvalues('ipv4', 'ipv6')
+    desc 'Name of the TCP/IP protocol to use (e.g: ipv4, ipv6, eb)'
+    newvalues('ipv4', 'ipv6', 'eb')
     defaultto('ipv4')
     munge(&:to_s)
   end

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -42,8 +42,8 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
   end
 
   newparam(:family) do
-    desc 'IP family, one of ipv4 or ipv6, defauts to ipv4'
-    newvalues(:ipv4, :ipv6)
+    desc 'IP family, one of ipv4, ipv6 or eb, defauts to ipv4'
+    newvalues(:ipv4, :ipv6, :eb)
     defaultto :ipv4
     munge(&:to_s)
   end

--- a/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
@@ -81,6 +81,32 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
     end
   end
 
+  describe 'eb protocol' do
+    let(:resource) do
+      described_class.new(
+        name: 'disable vnet stp',
+        ensure: 'present',
+        inet_protocol: 'eb',
+        table: 'filter',
+        chain: 'FORWARD',
+        priority: 10,
+        args: '-i vnet+ -d BGA -j DROP'
+      )
+    end
+
+    let(:provider) { resource.provider }
+
+    it 'creates' do
+      provider.expects(:execute_firewall_cmd).with(['--direct', '--add-rule', ['eb', 'filter', 'FORWARD', '10', '-i', 'vnet+', '-d', 'BGA', '-j', 'DROP']], nil)
+      provider.create
+    end
+
+    it 'destroys' do
+      provider.expects(:execute_firewall_cmd).with(['--direct', '--remove-rule', ['eb', 'filter', 'FORWARD', '10', '-i', 'vnet+', '-d', 'BGA', '-j', 'DROP']], nil)
+      provider.destroy
+    end
+  end
+
   context 'autorequires' do
     # rubocop:disable RSpec/InstanceVariable
     before do


### PR DESCRIPTION
see https://github.com/voxpupuli/puppet-firewalld/issues/298

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
allow usage of family "eb" for creating bridge-rules.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #298 