### PR TITLE
Add parameter to set 'AllowZoneDrifting'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class firewalld (
   Optional[String]                                              $default_zone              = undef,
   Optional[Enum['off','all','unicast','broadcast','multicast']] $log_denied                = undef,
   Optional[Enum['yes', 'no']]                                   $cleanup_on_exit           = undef,
+  Optional[Enum['yes', 'no']]                                   $zone_drifting             = undef,
   Optional[Integer]                                             $minimal_mark              = undef,
   Optional[Enum['yes', 'no']]                                   $lockdown                  = undef,
   Optional[Enum['yes', 'no']]                                   $ipv6_rpfilter             = undef,
@@ -195,6 +196,15 @@ class firewalld (
       'firewalld::cleanup_on_exit':
         changes => [
           "set CleanupOnExit \"${cleanup_on_exit}\"",
+        ];
+    }
+  }
+
+  if $zone_drifting {
+    augeas {
+      'firewalld::zone_drifting':
+        changes => [
+          "set AllowZoneDrifting \"${zone_drifting}\"",
         ];
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -276,6 +276,20 @@ describe 'firewalld' do
     end
   end
 
+  context 'with parameter zone_drifting' do
+    let(:params) do
+      {
+        zone_drifting: 'yes'
+      }
+    end
+
+    it do
+      is_expected.to contain_augeas('firewalld::zone_drifting').with(
+        changes: ['set AllowZoneDrifting "yes"']
+      )
+    end
+  end
+
   context 'with parameter minimal_mark' do
     let(:params) do
       {


### PR DESCRIPTION
#### Pull Request (PR) description
Per upstream[1], the setting 'AllowZoneDrifting' exists to control how zones interact.  Having this setting in the module would be handy as well.



[1] 
https://firewalld.org/2020/01/allowzonedrifting