### PR TITLE
Fixes firewalld_custom_service where only protocols are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,13 @@ will produce:
     <port protocol="tcp" port="8000-8002" />
 ```
 
+* `protocols`: (Optional) An array of protocols allowed by the service as defined
+  in /etc/protocols.
+
+  ```puppet
+     protocols => ['ospf'],
+  ```
+
 * `module`: (Optional) An array of strings specifying netfilter kernel helper
   modules associated with this service
 

--- a/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
@@ -119,9 +119,11 @@ Puppet::Type.type(:firewalld_custom_service).provide(
       to_remove = @property_hash[:protocols]
     else
       to_remove = @property_hash[:protocols] - should
-      to_add = (
-        should + Array(@resource[:ports]).select { |x| x['port'].nil? }.map { |x| x['protocol'] }
-      ) - @property_hash[:protocols]
+      ports_protos = []
+      unless @resource[:ports].include?(:unset)
+        ports_protos = Array(@resource[:ports]).select { |x| x['port'].nil? }.map { |x| x['protocol'] }
+      end
+      to_add = (should + ports_protos) - @property_hash[:protocols]
     end
 
     errors = []

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -200,6 +200,46 @@ describe 'firewalld', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) d
           apply_manifest_on(host, cleanup_manifest, catch_changes: true)
         end
       end
+
+      context 'with only protocols' do
+        let(:manifest) do
+          <<-EOM
+            firewalld_custom_service{ 'ospf':
+              protocols => ['ospf'],
+            }
+          EOM
+        end
+
+        it 'runs successfully' do
+          apply_manifest_on(host, manifest, catch_failures: true)
+        end
+
+        it 'is idempotent' do
+          apply_manifest_on(host, manifest, catch_changes: true)
+        end
+
+        context 'custom service' do
+          it 'exists' do
+            expect(on(host, 'firewall-cmd --permanent --info-service=ospf').output).not_to be_empty
+          end
+
+          it 'has the proper protocol' do
+            expect(on(host, 'firewall-cmd --permanent --service=ospf --get-protocols').output.strip).to eq('ospf')
+          end
+
+          it 'has no ports' do
+            expect(on(host, 'firewall-cmd --permanent --service=ospf --get-ports').output.strip).to be_empty
+          end
+
+          it 'has no modules' do
+            expect(on(host, 'firewall-cmd --permanent --service=ospf --get-modules').output.strip).to be_empty
+          end
+
+          it 'has no destinations' do
+            expect(on(host, 'firewall-cmd --permanent --service=ospf --get-destinations').output.strip).to be_empty
+          end
+        end
+      end
     end
 
     context 'disable firewalld' do


### PR DESCRIPTION
#### Pull Request (PR) description
Previously if you wanted to define a custom service that only allows protocols it would error when adding protocols to the service. This was caused by the Puppet code omitting the `ports` array and the provider assuming that the `ports` array was specified.

I simply added a check to see if `ports` array was `:unset` and if it's `:unset` just skip finding protocols from that array.

#### This Pull Request (PR) fixes the following issues
Fixes #306 