### PR TITLE
Set default_zone and log_denied when firewalld is offline

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,8 +166,8 @@ class firewalld (
 
   if $default_zone {
     exec { 'firewalld::set_default_zone':
-      command => "firewall-cmd --set-default-zone ${default_zone}",
-      unless  => "[ $(firewall-cmd --get-default-zone) = ${default_zone} ]",
+      command => "firewall-cmd --set-default-zone ${default_zone} || firewall-offline-cmd --set-default-zone ${default_zone}",
+      unless  => "[ $(firewall-cmd --get-default-zone || firewall-offline-cmd --get-default-zone) = ${default_zone} ]",
       require => Service['firewalld'],
     }
 
@@ -176,8 +176,8 @@ class firewalld (
 
   if $log_denied {
     exec { 'firewalld::set_log_denied':
-      command => "firewall-cmd --set-log-denied ${log_denied}",
-      unless  => "[ $(firewall-cmd --get-log-denied) = ${log_denied} ]",
+      command => "firewall-cmd --set-log-denied ${log_denied} || firewall-offline-cmd --set-log-denied ${log_denied}",
+      unless  => "[ $(firewall-cmd --get-log-denied || firewall-offline-cmd --get-log-denied) = ${log_denied} ]",
       require => Service['firewalld'],
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,8 +39,8 @@ describe 'firewalld' do
 
     it do
       is_expected.to contain_exec('firewalld::set_default_zone').with(
-        command: 'firewall-cmd --set-default-zone restricted',
-        unless: '[ $(firewall-cmd --get-default-zone) = restricted ]'
+        command: 'firewall-cmd --set-default-zone restricted || firewall-offline-cmd --set-default-zone restricted',
+        unless: '[ $(firewall-cmd --get-default-zone || firewall-offline-cmd --get-default-zone) = restricted ]'
       ).that_requires('Service[firewalld]')
     end
   end
@@ -239,8 +239,8 @@ describe 'firewalld' do
 
     it do
       is_expected.to contain_exec('firewalld::set_default_zone').with(
-        command: 'firewall-cmd --set-default-zone public',
-        unless: '[ $(firewall-cmd --get-default-zone) = public ]'
+        command: 'firewall-cmd --set-default-zone public || firewall-offline-cmd --set-default-zone public',
+        unless: '[ $(firewall-cmd --get-default-zone || firewall-offline-cmd --get-default-zone) = public ]'
       ).that_requires('Service[firewalld]')
     end
   end
@@ -255,8 +255,8 @@ describe 'firewalld' do
 
       it do
         is_expected.to contain_exec('firewalld::set_log_denied').with(
-          command: "firewall-cmd --set-log-denied #{cond}",
-          unless: "[ \$\(firewall-cmd --get-log-denied) = #{cond} ]"
+          command: "firewall-cmd --set-log-denied #{cond} || firewall-offline-cmd --set-log-denied #{cond}",
+          unless: "[ \$\(firewall-cmd --get-log-denied || firewall-offline-cmd --get-log-denied) = #{cond} ]"
         ).that_requires('Service[firewalld]')
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Change the exec resources that set default_zone and log_denied to fallback to the firewall-offline-cmd when firewalld is not running. This is useful, for example, in container environments or kickstart post-installs where the firewalld service can't be run but we still want these settings configured.

#### This Pull Request (PR) fixes the following issues
The bug this PR fixes does not have an associated issue.