### PR TITLE
Add the parameter `protocols` to the `firewalld_zone` resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ firewalld::zones:
 * `target`: Specify the target of the zone.
 * `interfaces`: An array of interfaces for this zone
 * `sources`: An array of sources for the zone
+* `protocols`: An array of protocols for the zone
 * `icmp_blocks`: An array of ICMP blocks for the zone
 * `masquerade`: If set to `true` or `false` specifies whether or not to add
   masquerading to the zone

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,9 +18,9 @@
 * [`firewalld_custom_service`](#firewalld_custom_service): Creates a custom firewalld service.
 * [`firewalld_direct_chain`](#firewalld_direct_chain): Allow to create a custom chain in iptables/ip6tables/ebtables using firewalld direct interface.  Example:      firewalld_direct_chain {'Add c
 * [`firewalld_direct_passthrough`](#firewalld_direct_passthrough): Allow to create a custom passthroughhrough traffic in iptables/ip6tables/ebtables using firewalld direct interface.  Example:      firewalld_
-* [`firewalld_direct_purge`](#firewalld_direct_purge): Allow to purge direct rules in iptables/ip6tables/ebtables using firewalld direct interface.  Example:      firewalld_direct_purge {'chain': 
+* [`firewalld_direct_purge`](#firewalld_direct_purge): Allow to purge direct rules in iptables/ip6tables/ebtables using firewalld direct interface.  Example:      firewalld_direct_purge {'chain':
 * [`firewalld_direct_rule`](#firewalld_direct_rule): Allow to pass rules directly to iptables/ip6tables/ebtables using firewalld direct interface.  Example:      firewalld_direct_rule {'Allow ou
-* [`firewalld_ipset`](#firewalld_ipset): Configure IPsets in Firewalld  Example:     firewalld_ipset {'internal net':         ensure   => 'present',         type     => 'hash:net',  
+* [`firewalld_ipset`](#firewalld_ipset): Configure IPsets in Firewalld  Example:     firewalld_ipset {'internal net':         ensure   => 'present',         type     => 'hash:net',
 * [`firewalld_port`](#firewalld_port): Assigns a port to a specific firewalld zone. firewalld_port will autorequire the firewalld_zone specified in the zone parameter so there is n
 * [`firewalld_rich_rule`](#firewalld_rich_rule): Manages firewalld rich rules.  firewalld_rich_rules will autorequire the firewalld_zone specified in the zone parameter so there is no need t
 * [`firewalld_service`](#firewalld_service): Assigns a service to a specific firewalld zone.
@@ -316,7 +316,7 @@ Trevor Vaughan <tvaughan@onyxpoint.com>
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 
@@ -998,6 +998,7 @@ firewalld_zone { 'restricted':
   target           => '%%REJECT%%',
   interfaces       => [],
   sources          => [],
+  protocols        => [],
   purge_rich_rules => true,
   purge_services   => true,
   purge_ports      => true,
@@ -1034,6 +1035,10 @@ Can be set to true or false, specifies whether to add or remove masquerading fro
 ##### `sources`
 
 Specify the sources for the zone
+
+##### `protocols`
+
+Specify the protocols for the zone
 
 ##### `icmp_blocks`
 

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:firewalld_zone).provide(
 
     self.target = (@resource[:target]) if @resource[:target]
     self.sources = (@resource[:sources]) if @resource[:sources]
+    self.protocols = (@resource[:protocols]) if @resource[:protocols]
     self.interfaces = @resource[:interfaces]
     self.icmp_blocks = (@resource[:icmp_blocks]) if @resource[:icmp_blocks]
     self.description = (@resource[:description]) if @resource[:description]
@@ -75,6 +76,23 @@ Puppet::Type.type(:firewalld_zone).provide(
     (cur_sources - new_sources).each do |s|
       debug("Removing source '#{s}' from zone #{@resource[:name]}")
       execute_firewall_cmd(['--remove-source', s])
+    end
+  end
+
+  def protocols
+    execute_firewall_cmd(['--list-protocols']).chomp.split(' ').sort || []
+  end
+
+  def protocols=(new_protocols)
+    new_protocols ||= []
+    cur_protocols = protocols
+    (new_protocols - cur_protocols).each do |p|
+      debug("Adding protocol '#{p}' to zone #{@resource[:name]}")
+      execute_firewall_cmd(['--add-protocol', p])
+    end
+    (cur_protocols - new_protocols).each do |p|
+    debug("Removing protocol '#{p}' from zone #{@resource[:name]}")
+    execute_firewall_cmd(['--remove-protocol', p])
     end
   end
 

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -109,6 +109,26 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
   end
 
+  newproperty(:protocols, array_matching: :all) do
+    desc 'Specify the protocols for the zone'
+
+    def insync?(is)
+      case should
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
+      else raise Puppet::Error, 'parameter protocols must be a string or array of strings!'
+      end
+    end
+
+    def is_to_s(value = []) # rubocop:disable Style/PredicateName
+      '[' + value.join(', ') + ']'
+    end
+
+    def should_to_s(value = [])
+      '[' + value.join(', ') + ']'
+    end
+  end
+
   newproperty(:icmp_blocks, array_matching: :all) do
     desc "Specify the icmp-blocks for the zone. Can be a single string specifying one icmp type,
           or an array of strings specifying multiple icmp types. Any blocks not specified here will be removed

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -27,6 +27,7 @@ describe provider_class do
         resource.expects(:[]).with(:name).returns('white').at_least_once
         resource.expects(:[]).with(:target).returns(nil).at_least_once
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
+        resource.expects(:[]).with(:protocols).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
         resource.expects(:[]).with(:description).returns(nil).at_least_once
@@ -46,6 +47,7 @@ describe provider_class do
         resource.expects(:[]).with(:name).returns('white').at_least_once
         resource.expects(:[]).with(:target).returns(nil).at_least_once
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
+        resource.expects(:[]).with(:protocols).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
         resource.expects(:[]).with(:description).returns(nil).at_least_once

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Type.type(:firewalld_zone) do
           end
         end
 
-        [:target, :icmp_blocks, :sources, :purge_rich_rules, :purge_services, :purge_ports].each do |param|
+        [:target, :icmp_blocks, :sources, :protocols, :purge_rich_rules, :purge_services, :purge_ports].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:property)
           end
@@ -35,7 +35,8 @@ describe Puppet::Type.type(:firewalld_zone) do
           target: '%%REJECT%%',
           interfaces: ['eth0'],
           icmp_blocks: ['redirect', 'router-advertisment'],
-          sources: ['192.168.2.2', '10.72.1.100']
+          sources: ['192.168.2.2', '10.72.1.100'],
+          protocols: ['icmp', 'igmp']
         )
       end
       let(:provider) do
@@ -71,6 +72,10 @@ describe Puppet::Type.type(:firewalld_zone) do
         provider.expects(:sources).returns([])
         provider.expects(:execute_firewall_cmd).with(['--add-source', '192.168.2.2'])
         provider.expects(:execute_firewall_cmd).with(['--add-source', '10.72.1.100'])
+
+        provider.expects(:protocols).returns([])
+        provider.expects(:execute_firewall_cmd).with(['--add-protocol', 'icmp'])
+        provider.expects(:execute_firewall_cmd).with(['--add-protocol', 'igmp'])
 
         provider.expects(:interfaces).returns([])
         provider.expects(:execute_firewall_cmd).with(['--add-interface', 'eth0'])
@@ -114,6 +119,18 @@ describe Puppet::Type.type(:firewalld_zone) do
         provider.expects(:execute_firewall_cmd).with(['--add-source', 'valy'])
         provider.expects(:execute_firewall_cmd).with(['--remove-source', 'valx'])
         provider.sources = ['valy']
+      end
+
+      it 'gets protocols' do
+        provider.expects(:execute_firewall_cmd).with(['--list-protocols']).returns('val val')
+        expect(provider.protocols).to eq(%w[val val])
+      end
+
+      it 'sets protocols' do
+        provider.expects(:protocols).returns(['valx'])
+        provider.expects(:execute_firewall_cmd).with(['--add-protocol', 'valy'])
+        provider.expects(:execute_firewall_cmd).with(['--remove-protocol', 'valx'])
+        provider.protocols = ['valy']
       end
 
       it 'gets icmp_blocks' do


### PR DESCRIPTION
Hello!

The module does not allow to add/modify protocols for a zone with the `firewalld_zone` resource type, but the parameter  can be used with the **firewall-cmd** tool like 
`firewall-cmd --zone=example --add-protocol=icmp`

See docs: [firewall-cmd](https://firewalld.org/documentation/man-pages/firewall-cmd)
