### PR TITLE
Fix rich rule with typed action

### DIFF
--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -100,8 +100,8 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
     return [] unless (action = @resource[:action])
     args = []
     if action.is_a?(Hash)
-      args << action[:action]
-      args << quote_keyval('type', action[:type])
+      args << action['action']
+      args << quote_keyval('type', action['type'])
     else
       args << action
     end

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -103,10 +103,10 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
     end
     validate do |value|
       if value.is_a?(Hash)
-        if value.keys.sort != [:action, :type]
+        if value.keys.sort != ['action', 'type']
           raise Puppet::Error, "Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got #{value}"
         end
-        _validate_action(value[:action])
+        _validate_action(value['action'])
       elsif value.is_a?(String)
         _validate_action(value)
       end

--- a/spec/unit/puppet/provider/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_rich_rule_spec.rb
@@ -58,7 +58,7 @@ describe provider_class do
         resource.expects(:[]).with(:log).returns(nil)
         resource.expects(:[]).with(:audit).returns(nil)
         resource.expects(:[]).with(:raw_rule).returns(nil)
-        resource.expects(:[]).with(:action).returns(action: 'reject', type: 'icmp-admin-prohibited')
+        resource.expects(:[]).with(:action).returns('action' => 'reject', 'type' => 'icmp-admin-prohibited')
         expect(provider.build_rich_rule).to eq('rule family="ipv4" destination address="192.168.0.1/32" service name="ssh" reject type="icmp-admin-prohibited"')
       end
     end

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -42,7 +42,7 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
       expect do
         described_class.new(
           title: 'SSH from barny',
-          action: { type: 'accepted', foo: 'bar' }
+          action: { 'type' => 'accepted', 'foo' => 'bar' }
         )
       end.to raise_error(%r{Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`})
     end
@@ -50,7 +50,7 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
       expect do
         described_class.new(
           title: 'SSH from barny',
-          action: { type: 'icmp-admin-prohibited', action: 'accepted' }
+          action: { 'type' => 'icmp-admin-prohibited', 'action' => 'accepted' }
         )
       end.to raise_error(%r{Authorized action values are `accept`, `reject`, `drop` or `mark`})
     end
@@ -219,9 +219,6 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
         end
         let(:fakeclass) { Class.new }
         let(:provider) { resource.provider }
-        let(:rawrule) do
-          'rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" accept'
-        end
 
         it 'queries the status' do
           fakeclass.stubs(:exitstatus).returns(0)

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -184,7 +184,31 @@ describe Puppet::Type.type(:firewalld_rich_rule) do
         icmp_type: 'echo',
         log: { 'level' => 'debug' },
         action: 'accept'
-      } => 'rule family="ipv4" destination address="10.0.1.2/24" icmp-type name="echo" log level="debug" accept'
+      } => 'rule family="ipv4" destination address="10.0.1.2/24" icmp-type name="echo" log level="debug" accept',
+
+      ## test reject
+      {
+        name: 'reject ssh',
+        ensure: 'present',
+        family: 'ipv4',
+        zone: 'restricted',
+        source: { 'address' => '10.0.1.2/24' },
+        service: 'ssh',
+        log: { 'level' => 'debug' },
+        action: 'reject'
+      } => 'rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject',
+
+      ## test reject + type (#193)
+      {
+        name: 'reject ssh tcp reset',
+        ensure: 'present',
+        family: 'ipv4',
+        zone: 'restricted',
+        source: { 'address' => '10.0.1.2/24' },
+        service: 'ssh',
+        log: { 'level' => 'debug' },
+        action: { 'action' => 'reject', 'type' => 'tcp-reset' }
+      } => 'rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset"',
 
     }
 


### PR DESCRIPTION
This updates the parsing to support a rich rule with a configured reject type.

It might be possible to use symbols for keys, but I couldn't get that to work and don't know enough ruby to sort it out.

Fixes: #193
Replaces: #194 

Prior to this change set, the rich rule would produce the below error message(s)
```
Failures:

  1) Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" queries the status
     Failure/Error: raise Puppet::Error, "Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got #{value}"

     Puppet::ResourceError:
       Parameter action failed on Firewalld_rich_rule[reject ssh tcp reset]: Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     # ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:463:in `validate'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:498:in `value='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:694:in `[]='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2548:in `block in set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `each'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2449:in `initialize'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `new'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:221:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:228:in `block (5 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Puppet::Error:
     #   Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     #   ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'

  2) Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" creates
     Failure/Error: raise Puppet::Error, "Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got #{value}"

     Puppet::ResourceError:
       Parameter action failed on Firewalld_rich_rule[reject ssh tcp reset]: Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     # ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:463:in `validate'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:498:in `value='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:694:in `[]='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2548:in `block in set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `each'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2449:in `initialize'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `new'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:221:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:233:in `block (5 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Puppet::Error:
     #   Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     #   ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'

  3) Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" destroys
     Failure/Error: raise Puppet::Error, "Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got #{value}"

     Puppet::ResourceError:
       Parameter action failed on Firewalld_rich_rule[reject ssh tcp reset]: Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     # ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:463:in `validate'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/parameter.rb:498:in `value='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:694:in `[]='
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2548:in `block in set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `each'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2542:in `set_parameters'
     # /usr/local/bundle/ruby/2.5.0/gems/puppet-6.27.0/lib/puppet/type.rb:2449:in `initialize'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `new'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:218:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:221:in `block (5 levels) in <top (required)>'
     # ./spec/unit/puppet/type/firewalld_rich_rule_spec.rb:238:in `block (5 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Puppet::Error:
     #   Rule action hash should contain `action` and `type` keys. Use a string if you only want to declare the action to be `accept` or `reject`. Got {"action"=>"reject", "type"=>"tcp-reset"}
     #   ./lib/puppet/type/firewalld_rich_rule.rb:107:in `block (3 levels) in <top (required)>'

Finished in 2.34 seconds (files took 2.74 seconds to load)
124 examples, 3 failures

Failed examples:

rspec './spec/unit/puppet/type/firewalld_rich_rule_spec.rb[1:4:10:1]' # Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" queries the status
rspec './spec/unit/puppet/type/firewalld_rich_rule_spec.rb[1:4:10:2]' # Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" creates
rspec './spec/unit/puppet/type/firewalld_rich_rule_spec.rb[1:4:10:3]' # Puppet::Type::Firewalld_rich_rule provider for rule rule family="ipv4" source address="10.0.1.2/24" service name="ssh" log level="debug" reject type="tcp-reset" destroys
```