### PR TITLE
Pass the protocols to custom_service

### DIFF
--- a/manifests/custom_service.pp
+++ b/manifests/custom_service.pp
@@ -38,6 +38,7 @@ define firewalld::custom_service (
       Enum['ipv4', 'ipv6'],
       String
   ]]                       $destination = undef,
+  Optional[Array[String]]  $protocols   = undef,
   String                   $filename    = $short,
   Stdlib::Unixpath         $config_dir  = '/etc/firewalld/services',
   Enum['present','absent'] $ensure      = 'present',
@@ -47,6 +48,7 @@ define firewalld::custom_service (
       'short'            => $short,
       'description'      => $description,
       'ports'            => $port,
+      'protocols'        => $protocols,
       'modules'          => $module,
       'ipv4_destination' => $destination.dig('ipv4'),
       'ipv6_destination' => $destination.dig('ipv6'),


### PR DESCRIPTION
#### Pull Request (PR) description

This allows you to specify `protocols` in through `firewalld::custom_service`, which are then passed on to `firewalld_custom_service`.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>