### PR TITLE
Add individual_calls parameter to set IndividualCalls

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -89,6 +89,7 @@ The following parameters are available in the `firewalld` class:
 * [`zone_drifting`](#zone_drifting)
 * [`minimal_mark`](#minimal_mark)
 * [`lockdown`](#lockdown)
+* [`individual_calls`](#individual_calls)
 * [`ipv6_rpfilter`](#ipv6_rpfilter)
 * [`firewall_backend`](#firewall_backend)
 * [`default_service_zone`](#default_service_zone)
@@ -288,6 +289,14 @@ Data type: `Optional[Integer]`
 Default value: ``undef``
 
 ##### <a name="lockdown"></a>`lockdown`
+
+Data type: `Optional[Enum['yes', 'no']]`
+
+
+
+Default value: ``undef``
+
+##### <a name="individual_calls"></a>`individual_calls`
 
 Data type: `Optional[Enum['yes', 'no']]`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class firewalld (
   Optional[Enum['yes', 'no']]                                   $zone_drifting             = undef,
   Optional[Integer]                                             $minimal_mark              = undef,
   Optional[Enum['yes', 'no']]                                   $lockdown                  = undef,
+  Optional[Enum['yes', 'no']]                                   $individual_calls          = undef,
   Optional[Enum['yes', 'no']]                                   $ipv6_rpfilter             = undef,
   Optional[Enum['iptables', 'nftables']]                        $firewall_backend          = undef,
   Optional[String]                                              $default_service_zone      = undef,
@@ -223,6 +224,15 @@ class firewalld (
       'firewalld::lockdown':
         changes => [
           "set Lockdown \"${lockdown}\"",
+        ];
+    }
+  }
+
+  if $individual_calls {
+    augeas {
+      'firewalld::lockdown':
+        changes => [
+          "set IndividualCalls \"${individual_calls}\"",
         ];
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -318,6 +318,20 @@ describe 'firewalld' do
     end
   end
 
+  context 'with parameter individual_calls' do
+    let(:params) do
+      {
+        individual_calls: 'yes'
+      }
+    end
+
+    it do
+      is_expected.to contain_augeas('firewalld::individual_calls').with(
+        changes: ['set IndividualCalls "yes"']
+      )
+    end
+  end
+
   context 'with parameter firewall_backend' do
     context 'with firewalld version' do
       let(:params) do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Playing with firewalld i've faced with some errors in debian. Changing  IndividualCalls parameter to yes perfectly fixes the problem and firewalld working as expected so I've added it to parameters.
#### This Pull Request (PR) fixes the following issues
```
firewalld[63415]: ERROR: '/usr/sbin/iptables-restore -w -n' failed: iptables-restore v1.8.2 (nf_tables): 
                                                           line 4: RULE_REPLACE failed (No such file or directory): rule in chain INPUT
                                                           line 4: RULE_REPLACE failed (No such file or directory): rule in chain OUTPUT
firewalld[63415]: ERROR: COMMAND_FAILED: '/usr/sbin/iptables-restore -w -n' failed: iptables-restore v1.8.2 (
                                                           line 4: RULE_REPLACE failed (No such file or directory): rule in chain INPUT
                                                           line 4: RULE_REPLACE failed (No such file or directory): rule in chain OUTPUT
```
