### PR TITLE
Revert icmp_block_inversion as tests don't pass

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1198,7 +1198,7 @@ not work, and will generate an error. This is a limitation of firewalld itself, 
 
 #### Examples
 
-##### Create a zone called `restricted` allowing only `echo-request` icmp types
+##### Create a zone called `restricted`
 
 ```puppet
 firewalld_zone { 'restricted':
@@ -1209,8 +1209,7 @@ firewalld_zone { 'restricted':
   purge_rich_rules     => true,
   purge_services       => true,
   purge_ports          => true,
-  icmp_blocks          => 'echo-request'
-  icmp_block_inversion => true,
+  icmp_blocks          => 'router-advertisement'
 }
 ```
 
@@ -1225,12 +1224,6 @@ Valid values: `present`, `absent`
 The basic property that the resource should be in.
 
 Default value: `present`
-
-##### `icmp_block_inversion`
-
-Valid values: `true`, `false`
-
-Can be set to true or false, specifies whether to set icmp_block_inversion from the zone
 
 ##### `icmp_blocks`
 

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -23,7 +23,6 @@ Puppet::Type.type(:firewalld_zone).provide(
     self.sources = (@resource[:sources]) if @resource[:sources]
     self.interfaces = @resource[:interfaces]
     self.icmp_blocks = (@resource[:icmp_blocks]) if @resource[:icmp_blocks]
-    self.icmp_block_inversion = (@resource[:icmp_block_inversion]) if @resource[:icmp_block_inversion]
     self.description = (@resource[:description]) if @resource[:description]
     self.short = (@resource[:short]) if @resource[:short]
   end
@@ -153,25 +152,6 @@ Puppet::Type.type(:firewalld_zone).provide(
       set_blocks.each do |block|
         execute_firewall_cmd(['--add-icmp-block', block])
       end
-    end
-  end
-
-  def icmp_block_inversion
-    if execute_firewall_cmd(['--query-icmp-block-inversion'], @resource[:name]).chomp == 'no'
-      :false
-    else
-      :true
-    end
-  end
-
-  def icmp_block_inversion=(bool)
-    case bool
-    when :true
-      debug("adding icmp block inversion for zone #{@resource[:name]}")
-      execute_firewall_cmd(['--add-icmp-block-inversion'], @resource[:name])
-    when :false
-      debug("removing icmp block inversion for zone #{@resource[:name]}")
-      execute_firewall_cmd(['--remove-icmp-block-inversion'], @resource[:name])
     end
   end
 

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:firewalld_zone) do
     Note that setting `ensure => 'absent'` to the built in firewalld zones will
     not work, and will generate an error. This is a limitation of firewalld itself, not the module.
 
-    @example Create a zone called `restricted` allowing only `echo-request` icmp types
+    @example Create a zone called `restricted`
       firewalld_zone { 'restricted':
         ensure               => present,
         target               => '%%REJECT%%',
@@ -28,8 +28,7 @@ Puppet::Type.newtype(:firewalld_zone) do
         purge_rich_rules     => true,
         purge_services       => true,
         purge_ports          => true,
-        icmp_blocks          => 'echo-request'
-        icmp_block_inversion => true,
+        icmp_blocks          => 'router-advertisement'
       }
   DOC
 
@@ -124,12 +123,6 @@ Puppet::Type.newtype(:firewalld_zone) do
       else raise Puppet::Error, 'parameter icmp_blocks must be a string or array of strings!'
       end
     end
-  end
-
-  newproperty(:icmp_block_inversion) do
-    desc 'Can be set to true or false, specifies whether to set icmp_block_inversion from the zone'
-    newvalue(:true)
-    newvalue(:false)
   end
 
   newproperty(:purge_rich_rules) do

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -31,7 +31,6 @@ describe provider_class do
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
-        resource.expects(:[]).with(:icmp_block_inversion).returns(false).at_least_once
         resource.expects(:[]).with(:description).returns(nil).at_least_once
         resource.expects(:[]).with(:short).returns('little description').at_least_once
         provider.expects(:execute_firewall_cmd).with(['--list-interfaces'])
@@ -51,7 +50,6 @@ describe provider_class do
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
-        resource.expects(:[]).with(:icmp_block_inversion).returns(false).at_least_once
         resource.expects(:[]).with(:description).returns(nil).at_least_once
         resource.expects(:[]).with(:short).returns('little description').at_least_once
         provider.expects(:execute_firewall_cmd).with(['--list-interfaces'])

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Type.type(:firewalld_zone) do
           end
         end
 
-        %i[target icmp_blocks icmp_block_inversion sources purge_rich_rules purge_services purge_ports].each do |param|
+        %i[target icmp_blocks sources purge_rich_rules purge_services purge_ports].each do |param|
           it "has a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:property)
           end
@@ -37,7 +37,6 @@ describe Puppet::Type.type(:firewalld_zone) do
           target: '%%REJECT%%',
           interfaces: ['eth0'],
           icmp_blocks: %w[redirect router-advertisment],
-          icmp_block_inversion: true,
           sources: ['192.168.2.2', '10.72.1.100']
         )
       end
@@ -70,7 +69,6 @@ describe Puppet::Type.type(:firewalld_zone) do
         provider.expects(:execute_firewall_cmd).with(['--set-target', '%%REJECT%%'])
 
         provider.expects(:icmp_blocks=).with(%w[redirect router-advertisment])
-        provider.expects(:icmp_block_inversion=).with(:true)
 
         provider.expects(:sources).returns([])
         provider.expects(:execute_firewall_cmd).with(['--add-source', '192.168.2.2'])
@@ -118,11 +116,6 @@ describe Puppet::Type.type(:firewalld_zone) do
         provider.expects(:execute_firewall_cmd).with(['--add-source', 'valy'])
         provider.expects(:execute_firewall_cmd).with(['--remove-source', 'valx'])
         provider.sources = ['valy']
-      end
-
-      it 'sets icmp_block_inversion' do
-        provider.expects(:execute_firewall_cmd).with(['--query-icmp-block-inversion'], 'restricted').returns('no')
-        provider.expects(:execute_firewall_cmd).with(['--add-icmp-block-inversion'], 'restricted')
       end
 
       it 'gets icmp_blocks' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The tests for ICMP block inversion don't pass and I don't know why.  Someone with the relevant knowledge is welcome to submit a patch that does pass the tests.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
