### PR TITLE
Add the parameter protocols to the firewalld_zone resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ firewalld::zones:
 * `target`: Specify the target of the zone.
 * `interfaces`: An array of interfaces for this zone
 * `sources`: An array of sources for the zone
+* `protocols`: An array of protocols for the zone
 * `icmp_blocks`: An array of ICMP blocks for the zone
 * `masquerade`: If set to `true` or `false` specifies whether or not
   to add masquerading to the zone

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1255,6 +1255,10 @@ Valid values: `true`, `false`
 
 Can be set to true or false, specifies whether to add or remove masquerading from the zone
 
+##### `protocols`
+
+Specify the protocols for the zone
+
 ##### `purge_ports`
 
 Valid values: `false`, `true`

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:firewalld_zone).provide(
 
     self.target = (@resource[:target]) if @resource[:target]
     self.sources = (@resource[:sources]) if @resource[:sources]
+    self.protocols = (@resource[:protocols]) if @resource[:protocols]
     self.interfaces = @resource[:interfaces]
     self.icmp_blocks = (@resource[:icmp_blocks]) if @resource[:icmp_blocks]
     self.icmp_block_inversion = (@resource[:icmp_block_inversion]) if @resource[:icmp_block_inversion]
@@ -79,6 +80,23 @@ Puppet::Type.type(:firewalld_zone).provide(
     (cur_sources - new_sources).each do |extraneous_source|
       debug("Removing source '#{extraneous_source}' from zone #{@resource[:name]}")
       execute_firewall_cmd(['--remove-source', extraneous_source])
+    end
+  end
+
+  def protocols
+    execute_firewall_cmd(['--list-protocols']).chomp.split.sort || []
+  end
+
+  def protocols=(new_protocols)
+    new_protocols ||= []
+    cur_protocols = protocols
+    (new_protocols - cur_protocols).each do |p|
+      debug("Adding protocol '#{p}' to zone #{@resource[:name]}")
+      execute_firewall_cmd(['--add-protocol', p])
+    end
+    (cur_protocols - new_protocols).each do |p|
+      debug("Removing protocol '#{p}' from zone #{@resource[:name]}")
+      execute_firewall_cmd(['--remove-protocol', p])
     end
   end
 

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -114,6 +114,26 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
   end
 
+  newproperty(:protocols, array_matching: :all) do
+    desc 'Specify the protocols for the zone'
+
+    def insync?(is)
+      case should
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
+      else raise Puppet::Error, 'parameter protocols must be a string or array of strings!'
+      end
+    end
+
+    def is_to_s(value = [])
+      "[#{value.join(', ')}]"
+    end
+
+    def should_to_s(value = [])
+      "[#{value.join(', ')}]"
+    end
+  end
+
   newproperty(:icmp_blocks, array_matching: :all) do
     desc "Specify the icmp-blocks for the zone. Can be a single string specifying one icmp type,
           or an array of strings specifying multiple icmp types. Any blocks not specified here will be removed

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -29,6 +29,7 @@ describe provider_class do
         resource.expects(:[]).with(:name).returns('white').at_least_once
         resource.expects(:[]).with(:target).returns(nil).at_least_once
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
+        resource.expects(:[]).with(:protocols).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
         resource.expects(:[]).with(:icmp_block_inversion).returns(false).at_least_once
@@ -49,6 +50,7 @@ describe provider_class do
         resource.expects(:[]).with(:name).returns('white').at_least_once
         resource.expects(:[]).with(:target).returns(nil).at_least_once
         resource.expects(:[]).with(:sources).returns(nil).at_least_once
+        resource.expects(:[]).with(:protocols).returns(nil).at_least_once
         resource.expects(:[]).with(:interfaces).returns(['eth0']).at_least_once
         resource.expects(:[]).with(:icmp_blocks).returns(nil).at_least_once
         resource.expects(:[]).with(:icmp_block_inversion).returns(false).at_least_once


### PR DESCRIPTION
Rebased off of : https://github.com/voxpupuli/puppet-firewalld/pull/327

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
https://github.com/voxpupuli/puppet-firewalld/pull/327

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
