### PR TITLE
Fixes missing IPv6 support in firewalld_ipset

### DIFF
--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:firewalld_ipset) do
     end
 
     munge do |value|
-      value.gsub('/32', '')
+      value.gsub(/(\b(?:\d{1,3}\.){3}\d{1,3})\/32\b|(\b[0-9a-fA-F:]+)\/128\b/) { |m| $1 || $2 }
     end
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,21 +186,21 @@ class firewalld (
   #...ipsets
   $ipsets.each | String $key, Hash $attrs| {
     firewalld_ipset { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   #...zones
   $zones.each | String $key, Hash $attrs| {
     firewalld_zone { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   #...policies
   $policies.each | String $key, Hash $attrs| {
     firewalld_policy { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
@@ -212,7 +212,7 @@ class firewalld (
 
   $ports.each |String $key, Hash $attrs| {
     firewalld_port { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
@@ -224,39 +224,39 @@ class firewalld (
   #...custom services
   $custom_services.each | String $key, Hash $attrs| {
     firewalld_custom_service { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   $services.each | String $key, Hash $attrs| {
     firewalld_service { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   # Direct rules, chains and passthroughs
   $direct_chains.each | String $key, Hash $attrs| {
     firewalld_direct_chain { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   $direct_rules.each | String $key, Hash $attrs| {
     firewalld_direct_rule { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   $direct_passthroughs.each | String $key, Hash $attrs| {
     firewalld_direct_passthrough { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 
   #...rich rules
   $rich_rules.each | String $key, Hash $attrs| {
     firewalld_rich_rule { $key:
-      *       => $attrs,
+      * => $attrs,
     }
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
There's an issue in relation to IPv6 addresses, where `/32` is stripped where it shouldn't, as the current code only takes IPv4 addresses into account.

It also does not strip /128 (like it should) for IPv6 addresses.

This PR addresses both cases.

#### This Pull Request (PR) fixes the following issues
Fixes #287 