### PR TITLE
Follow-up lint fixes for PR #381 + upgrade beaker to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ concurrency:
 jobs:
   puppet:
     name: Puppet
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:firewalld_ipset) do
     end
 
     munge do |value|
-      value.gsub(/(\b(?:\d{1,3}\.){3}\d{1,3})\/32\b|(\b[0-9a-fA-F:]+)\/128\b/) { |m| $1 || $2 }
+      value.gsub(%r{(?<ipv4>\b(?:\d{1,3}\.){3}\d{1,3})/32\b|(?<ipv6>\b[0-9a-fA-F:]+)/128\b}) { Regexp.last_match[:ipv4] || Regexp.last_match[:ipv6] }
     end
   end
 


### PR DESCRIPTION
Hi,

Now that the other PR was merged that fixed the errors in `manifests/init.pp`, I can see the `rubocop` linting warnings.

This should be a cleaner and much more readable version, since escapes are not needed when using `%r{...}` and named capture groups to make it apparent what's going on.

Code should be compatible with Ruby 1.9+. Surely that is sufficient.

Feel free to make changes you see fit if needed.