### PR TITLE
(#issue_389) Added el10 support to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,14 +24,16 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -39,14 +41,16 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
Tests pass locally on CentOS 10, however, other flavors of el10 don't currently appear to be available for testing.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds metadata support for el10 os flavors

#### This Pull Request (PR) fixes the following issues
Fixes #389 
